### PR TITLE
Custom data normalization fix

### DIFF
--- a/lib/backend/util/index.js
+++ b/lib/backend/util/index.js
@@ -25,10 +25,13 @@ function cbifyData(input, normalizerConfig) {
         delete input[normalizerConfig[value]];
     });
     cbfiedData["custom_data"] = {};
-    Object.keys(input).forEach(function (value) {
-        //@ts-ignore
-        cbfiedData["custom_data"][value] = input[value];
-    });
+    //Process the custom_data structure
+    if (!!normalizerConfig.custom_data) {
+        Object.keys(normalizerConfig.custom_data).forEach(function (value) {
+            //@ts-ignore
+            cbfiedData["custom_data"][value] = input[normalizerConfig.custom_data[value]];
+        });
+    }
     return cbfiedData;
 }
 exports.cbifyData = cbifyData;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearblade/asset-monitor",
-  "version": "1.1.9",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearblade/asset-monitor",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearblade/asset-monitor",
-  "version": "1.1.9",
+  "version": "1.1.8",
   "description": "Asset Monitor Biolerplate",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clearblade/asset-monitor",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "description": "Asset Monitor Biolerplate",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/backend/Util/index.ts
+++ b/src/backend/Util/index.ts
@@ -32,10 +32,14 @@ export function cbifyData(
     delete input[normalizerConfig[value]];
   });
   cbfiedData["custom_data"] = {};
-  Object.keys(input).forEach(function(value) {
-    //@ts-ignore
-    cbfiedData["custom_data"][value] = input[value];
-  });
+  
+  //Process the custom_data structure
+  if (!!normalizerConfig.custom_data) {
+    Object.keys(normalizerConfig.custom_data).forEach(function (value) {
+      //@ts-ignore
+      cbfiedData["custom_data"][value] = input[normalizerConfig.custom_data[value]];
+    });
+  }
   return cbfiedData;
 }
 


### PR DESCRIPTION
Correctly normalizes custom data based on the contents of the customConfig object.

Before change:
    "custom_data": {
      "temp.tc": 0,
      "temp.lvl": 2,
      "temp.c": 15.69,
      "temp.rh": 24.014
    }


After change:
  "custom_data": {
    "temperatureSamplesAveraged": 0,
    "temperatureLevel": 3,
    "temperatureCelsius": 23.688,
    "relativeHumidity": 18.091
  }
