### PR TITLE
Modify error logging to utilize error.message

### DIFF
--- a/src/backend/Normalizer/index.ts
+++ b/src/backend/Normalizer/index.ts
@@ -81,8 +81,8 @@ export function normalizer(config: NormalizerConfig): void {
         subscribePromises.push(subscriber(config.topics[i]));
     }
 
-    function failureCb(reason: unknown): void {
-        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', JSON.stringify(reason));
+    function failureCb(error: Error): void {
+        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', error.message);
     }
 
     function HandleMessage(err: boolean, msg: string, topic: string): void {

--- a/src/backend/Normalizer/index.ts
+++ b/src/backend/Normalizer/index.ts
@@ -1,6 +1,7 @@
 import { Logger } from '../Logger';
 import { GC, LogLevels } from '../global-config';
 import { Asset } from '../collection-schema/Assets';
+import { getErrorMessage } from '../Util'
 import '../../static/promise-polyfill/index.js';
 
 export type MessageParser = (err: boolean, msg: string, topic: string) => Promise<Array<Asset>>;
@@ -81,8 +82,8 @@ export function normalizer(config: NormalizerConfig): void {
         subscribePromises.push(subscriber(config.topics[i]));
     }
 
-    function failureCb(error: Error): void {
-        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', error.message);
+    function failureCb(reason: unknown): void {
+        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', getErrorMessage(reason));
     }
 
     function HandleMessage(err: boolean, msg: string, topic: string): void {

--- a/src/backend/Normalizer/index.ts
+++ b/src/backend/Normalizer/index.ts
@@ -100,8 +100,8 @@ export function normalizer(config: NormalizerConfig): void {
         subscribePromises.push(subscriber(config.topics[i]));
     }
 
-    function failureCb(reason: unknown): void {
-        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', getErrorMessage(reason));
+    function failureCb(error: Error | string): void {
+        logger.publishLog(LogLevels.ERROR, SERVICE_INSTANCE_ID, ': Failed ', getErrorMessage(error));
     }
 
     function HandleMessage(err: boolean, msg: string, topic: string): void {

--- a/src/backend/Normalizer/index.ts
+++ b/src/backend/Normalizer/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../Logger';
 import { GC, LogLevels } from '../global-config';
 import { Asset } from '../collection-schema/Assets';
-import { getErrorMessage } from '../Util'
+import { getErrorMessage } from '../Util';
 import '../../static/promise-polyfill/index.js';
 
 export type MessageParser = (err: boolean, msg: string, topic: string) => Promise<Array<Asset>>;

--- a/src/backend/Util/index.ts
+++ b/src/backend/Util/index.ts
@@ -132,3 +132,11 @@ export function isNormalizedDataValid(normalizedData: Array<Asset>): boolean {
     }
     return true;
 }
+
+export function getErrorMessage(error: unknown): string {
+    if (typeof error === 'object' && !!error && !!error.message) {
+        return error.message;
+    } else {
+        return JSON.stringify(error);
+    }
+}

--- a/src/backend/Util/index.ts
+++ b/src/backend/Util/index.ts
@@ -133,7 +133,7 @@ export function isNormalizedDataValid(normalizedData: Array<Asset>): boolean {
     return true;
 }
 
-export function getErrorMessage(error: unknown): string {
+export function getErrorMessage(error: Error | string): string {
     if (!!error && typeof error === 'object') {
         if (error.stack) {
             return error.stack;
@@ -145,6 +145,6 @@ export function getErrorMessage(error: unknown): string {
             }
         }
     } else {
-        return error as string;
+        return error;
     }
 }

--- a/src/backend/asset-history/index.ts
+++ b/src/backend/asset-history/index.ts
@@ -142,7 +142,7 @@ export function createAssetHistorySS({
         try {
             parsedMsg = JSON.parse(msg);
         } catch (e) {
-            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', e);
+            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', e.message);
             return;
         }
         let assetHistoryItems: Array<AssetHistory> = [];

--- a/src/backend/asset-history/index.ts
+++ b/src/backend/asset-history/index.ts
@@ -3,7 +3,7 @@ import { Asset } from '../collection-schema/Assets';
 import { AssetHistory } from '../collection-schema/AssetHistory';
 import { CbCollectionLib } from '../collection-lib';
 import { Logger } from '../Logger';
-import { Topics } from '../Util';
+import { Topics, getErrorMessage } from '../Util';
 interface CreateAssetHistoryConfig {
     req: CbServer.BasicReq;
     resp: CbServer.Resp;
@@ -40,7 +40,7 @@ export function createAssetHistorySS({
     }
 
     function failureCb(reason: unknown): void {
-        logger.publishLog(LogLevels.ERROR, 'Failed ', reason);
+        logger.publishLog(LogLevels.ERROR, 'Failed ', getErrorMessage(reason));
     }
 
     function getEmptyAssetHistoryObject(): AssetHistory {
@@ -142,7 +142,7 @@ export function createAssetHistorySS({
         try {
             parsedMsg = JSON.parse(msg);
         } catch (e) {
-            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', e.message);
+            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', getErrorMessage(e));
             return;
         }
         let assetHistoryItems: Array<AssetHistory> = [];

--- a/src/backend/asset-location/index.ts
+++ b/src/backend/asset-location/index.ts
@@ -99,7 +99,7 @@ export function updateAssetLocationSS({
         try {
             newAsset['custom_data'] = JSON.stringify(assetData['custom_data']);
         } catch (e) {
-            logger.publishLog(LogLevels.ERROR, 'ERROR: ', SERVICE_INSTANCE_ID, ': Failed to stringify ', e);
+            logger.publishLog(LogLevels.ERROR, 'ERROR: ', SERVICE_INSTANCE_ID, ': Failed to stringify ', e.message);
             return Promise.reject('Failed to stringify ' + e);
         }
 
@@ -116,7 +116,7 @@ export function updateAssetLocationSS({
         try {
             incomingMsg = JSON.parse(msg);
         } catch (e) {
-            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', e);
+            logger.publishLog(LogLevels.ERROR, 'Failed parse the message: ', e.message);
 
             return;
         }
@@ -155,8 +155,8 @@ export function updateAssetLocationSS({
                     logger.publishLog(LogLevels.ERROR, 'ERROR: Multiple Assets with same assetId exists: ', data);
                 }
             })
-            .catch(function(reason) {
-                logger.publishLog(LogLevels.ERROR, 'Failed to fetch: ', reason);
+            .catch(function(error) {
+                logger.publishLog(LogLevels.ERROR, 'Failed to fetch: ', error.message);
             });
 
         Promise.runQueue();

--- a/src/backend/asset-location/index.ts
+++ b/src/backend/asset-location/index.ts
@@ -2,7 +2,7 @@ import { GC, CollectionName, UpdateAssetLocationOptions, LogLevels } from '../gl
 import { Asset } from '../collection-schema/Assets';
 import { CbCollectionLib } from '../collection-lib';
 import { Logger } from '../Logger';
-import { Topics } from '../Util';
+import { Topics, getErrorMessage } from '../Util';
 
 interface UpdateAssetLocationDataOptions {
     fetchedData: CbServer.CollectionSchema;
@@ -100,7 +100,7 @@ export function updateAssetLocationSS({
             newAsset['custom_data'] = JSON.stringify(assetData['custom_data']);
         } catch (e) {
             logger.publishLog(LogLevels.ERROR, 'ERROR: ', SERVICE_INSTANCE_ID, ': Failed to stringify ', e.message);
-            return Promise.reject('Failed to stringify ' + e);
+            return Promise.reject('Failed to stringify ' + e.message);
         }
 
         return assetsCol.cbCreatePromise({ item: [newAsset] as Record<string, unknown>[] });
@@ -156,7 +156,7 @@ export function updateAssetLocationSS({
                 }
             })
             .catch(function(error) {
-                logger.publishLog(LogLevels.ERROR, 'Failed to fetch: ', error.message);
+                logger.publishLog(LogLevels.ERROR, 'Failed to fetch: ', getErrorMessage(error));
             });
 
         Promise.runQueue();

--- a/src/backend/asset-status/index.ts
+++ b/src/backend/asset-status/index.ts
@@ -1,7 +1,7 @@
 import { GC, CollectionName, UpdateAssetStatusOptions, LogLevels, AssetStatusUpdateMethod } from '../global-config';
 import { CbCollectionLib } from '../collection-lib';
 import { Logger } from '../Logger';
-import { Topics } from '../Util';
+import { Topics, getErrorMessage } from '../Util';
 import { Asset } from '../collection-schema/Assets';
 
 interface UpdateAssetStatusConfig {
@@ -28,8 +28,8 @@ export function updateAssetStatusSS({
     const logger = Logger({ name: 'AssetStatusSSLib', logSetting: LOG_SETTING });
     const messaging = ClearBlade.Messaging();
 
-    function failureCb(error: Error): void {
-        logger.publishLog(LogLevels.ERROR, 'Failed ', error.message);
+    function failureCb(reason: unknown): void {
+        logger.publishLog(LogLevels.ERROR, 'Failed ', getErrorMessage(reason));
     }
 
     function MergeAsset(assetID: string, msg: Asset): Promise<unknown> {

--- a/src/backend/asset-status/index.ts
+++ b/src/backend/asset-status/index.ts
@@ -28,8 +28,8 @@ export function updateAssetStatusSS({
     const logger = Logger({ name: 'AssetStatusSSLib', logSetting: LOG_SETTING });
     const messaging = ClearBlade.Messaging();
 
-    function failureCb(reason: unknown): void {
-        logger.publishLog(LogLevels.ERROR, 'Failed ', reason);
+    function failureCb(error: Error): void {
+        logger.publishLog(LogLevels.ERROR, 'Failed ', error.message);
     }
 
     function MergeAsset(assetID: string, msg: Asset): Promise<unknown> {
@@ -51,8 +51,8 @@ export function updateAssetStatusSS({
             try {
                 customData = JSON.parse(dataStr);
             } catch (e) {
-                logger.publishLog(LogLevels.ERROR, 'Failed while parsing: ', e);
-                return Promise.reject('Failed while parsing: ' + e);
+                logger.publishLog(LogLevels.ERROR, 'Failed while parsing: ', e.message);
+                return Promise.reject('Failed while parsing: ' + e.message);
             }
             const incomingCustomData = msg['custom_data'];
             for (const key of Object.keys(incomingCustomData as object)) {
@@ -81,7 +81,7 @@ export function updateAssetStatusSS({
         try {
             jsonMessage = JSON.parse(msg);
         } catch (e) {
-            logger.publishLog(LogLevels.ERROR, 'Failed while parsing: ', e);
+            logger.publishLog(LogLevels.ERROR, 'Failed while parsing: ', e.message);
             return;
         }
         // Update for Jim/Ryan; Might fail for AD if used directly..

--- a/src/backend/collection-lib/index.ts
+++ b/src/backend/collection-lib/index.ts
@@ -49,7 +49,7 @@ export function CbCollectionLib(collectionName: CollectionName): CbCollectionLib
             const col = ClearBlade.Collection({ collectionName });
             col.create(opts.item, function(err, res) {
                 if (err) {
-                    reject(new Error(res));
+                    reject(new Error(JSON.stringify(res)));
                 } else {
                     resolve(res);
                 }
@@ -100,7 +100,7 @@ export function CbCollectionLib(collectionName: CollectionName): CbCollectionLib
             col.fetch(query, function(err, res) {
                 if (err) {
                     logger.publishLog(GC.LOG_LEVEL.ERROR, 'ERROR: with fetch ' + res);
-                    reject(new Error(res));
+                    reject(new Error(JSON.stringify(res)));
                 } else {
                     logger.publishLog(GC.LOG_LEVEL.DEBUG, 'DEBUG: Fetched Success: ' + collectionName);
                     resolve(res);


### PR DESCRIPTION
Errors are currently be logged as "Normalizer ["7f23792c-5048-4f4b-8ee0-6188dd9be2b0",": Failed ","{}"]"

Changing to use error.message will result in the error message being printed, rather than an empty object.