### PR TITLE
if areaType or assetType is an empty string - don't query for type so…

### DIFF
--- a/src/backend/RulesEngine/async.ts
+++ b/src/backend/RulesEngine/async.ts
@@ -11,7 +11,9 @@ import { Rules } from '../collection-schema/Rules';
 export function getAllAssetsForType(assetType: string): Promise<Array<CbServer.CollectionSchema<Asset>>> {
     const assetsCollection = CbCollectionLib(CollectionName.ASSETS);
     const assetsCollectionQuery = ClearBlade.Query({ collectionName: CollectionName.ASSETS });
-    assetsCollectionQuery.equalTo('type', assetType);
+    if (assetType !== '') {
+        assetsCollectionQuery.equalTo('type', assetType);
+    }
 
     const promise = assetsCollection.cbFetchPromise({ query: assetsCollectionQuery }).then(data => {
         return Array.isArray(data.DATA) ? data.DATA : [];
@@ -23,7 +25,9 @@ export function getAllAssetsForType(assetType: string): Promise<Array<CbServer.C
 export function getAllAreasForType(areaType: string): Promise<Array<CbServer.CollectionSchema<Areas>>> {
     const areasCollection = CbCollectionLib(CollectionName.AREAS);
     const areasCollectionQuery = ClearBlade.Query({ collectionName: CollectionName.AREAS });
-    areasCollectionQuery.equalTo('type', areaType);
+    if (areaType !== '') {
+        areasCollectionQuery.equalTo('type', areaType);
+    }
 
     const promise = areasCollection.cbFetchPromise({ query: areasCollectionQuery }).then(data => {
         return Array.isArray(data.DATA) ? data.DATA : [];


### PR DESCRIPTION
… that the engine pulls back all areas/assets